### PR TITLE
get_commit_body: prevent exception when branch name is a filename

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -187,7 +187,7 @@ def parse_pr_message(message):
 
 def git_get_commit_body(commit):
     return _run_shell_command(
-        ["git", "show", "-q", "--format=%b", commit],
+        ["git", "show", "-q", "--format=%b", commit, '--'],
         output=True)
 
 


### PR DESCRIPTION
This changes adds a filename separator to the git show command to
prevent an exception from happening when the branch name is a filename:
fatal: ambiguous argument 'name': both revision and filename