### PR TITLE
Always run the editor by default

### DIFF
--- a/git_pull_request/tests/test_gpr.py
+++ b/git_pull_request/tests/test_gpr.py
@@ -126,10 +126,10 @@ class TestGitCommand(fixtures.TestWithFixtures):
                                 "-m", "Last message\n\nLong body, "
                                 "but not so long\n"])
 
-        self.assertEqual((1, "Last message", "Long body, but not so long"),
+        self.assertEqual(("Last message", "Long body, but not so long"),
                          gpr.git_get_title_and_message("master^", "master"))
 
-        self.assertEqual((2, "Pull request for master",
+        self.assertEqual(("Pull request for master",
                           "Last message\nFirst message"),
                          gpr.git_get_title_and_message("master^^", "master"))
 
@@ -167,10 +167,10 @@ class TestGithubPRTemplate(fixtures.TestWithFixtures):
                   "PULL_REQUEST_TEMPLATE.md"), "w+") as pr_template:
             pr_template.write("# test")
 
-        self.assertEqual((1, "Last message", "# test"),
+        self.assertEqual(("Last message", "# test"),
                          gpr.git_get_title_and_message("master^", "master"))
 
-        self.assertEqual((2, "Pull request for master", "# test"),
+        self.assertEqual(("Pull request for master", "# test"),
                          gpr.git_get_title_and_message("master^^", "master"))
 
 


### PR DESCRIPTION
The current way of detecting if the editor has to run or not is clumsy. From
now on, we always run the editor just like git would do. It's up to users to
pass `cat` as an editor if they're not happy with it.