### PR TITLE
Allow ssh:// URL

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -184,6 +184,8 @@ def get_hosttype_hostname_user_repo_from_url(url):
     else:
         path = parsed.path[1:].rstrip('/')
         host = parsed.netloc
+        if "@" in host:
+            username, sep, host = host.partition("@")
     hosttype = get_hosttype(host)
     if hosttype == "pagure":
         user, repo = None, path

--- a/git_pull_request/tests/test_gpr.py
+++ b/git_pull_request/tests/test_gpr.py
@@ -73,6 +73,10 @@ class TestStuff(BaseTestGitRepo):
             ("github", "example.com", "jd", "git-pull-request"),
             gpr.get_hosttype_hostname_user_repo_from_url(
                 "https://example.com/jd/git-pull-request"))
+        self.assertEqual(
+            ("github", "example.com:2222", "jd", "git-pull-request"),
+            gpr.get_hosttype_hostname_user_repo_from_url(
+                "ssh://git@example.com:2222/jd/git-pull-request"))
         gpr.git_set_config_hosttype("pagure")
         self.assertEqual(
             ("pagure", "pagure.io", None, "pagure"),


### PR DESCRIPTION
This is mostly useful if you need to specify a different SSH port.