### PR TITLE
Improve reliability of remote matching.

### DIFF
--- a/git_pull_request/tests/test_gpr.py
+++ b/git_pull_request/tests/test_gpr.py
@@ -95,6 +95,8 @@ class TestGitCommand(fixtures.TestWithFixtures):
         gpr._run_shell_command(["git", "init", "--quiet"])
         gpr._run_shell_command(["git", "remote", "add", "origin",
                                 "https://github.com/jd/git-pull-request.git"])
+        gpr._run_shell_command(["git", "remote", "add", "fork",
+                                "git@github.com:Flameeyes/git-pull-request"])
         gpr._run_shell_command(["git", "config", "branch.master.merge",
                                 "refs/heads/master"])
         gpr._run_shell_command(["git", "config", "branch.master.remote",
@@ -112,6 +114,14 @@ class TestGitCommand(fixtures.TestWithFixtures):
             "origin",
             gpr.git_remote_matching_url(
                 "https://github.com/jd/git-pull-request.git"))
+        self.assertEqual(
+            "fork",
+            gpr.git_remote_matching_url(
+                "https://github.com/Flameeyes/git-pull-request.git"))
+        self.assertEqual(
+            "fork",
+            gpr.git_remote_matching_url(
+                "https://github.com/flameeyes/Git-Pull-Request.git"))
 
     def test_git_get_remote_branch_for_branch(self):
         self.assertEqual(


### PR DESCRIPTION
Instead of looking for the literal URL, decompose both the URL that is
being searched for, and each of the remote URLs, and compare the tuple
instead.

This allows matching git remotes when looking for https URLs, and work even
when the user has configured something like:

    url.git@github.com:.pushinsteadof=http://github.com/
    url.git@github.com:.pushinsteadof=https://github.com/
    url.git@github.com:.pushinsteadof=git://github.com/

Also, apply a lower() call to the URL when decomposing it. While I don't
know Pagure that well, GitHub is case insensitive on both the username and
repository names.