### PR TITLE
Workaround case-sensitivity in pull request API.

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -52,9 +52,6 @@ class RepositoryId:
             self.user.lower() == other.user.lower() and
             self.repository.lower() == other.repository.lower())
 
-    def __iter__(self):
-        return attr.astuple(self)
-
 
 def _run_shell_command(cmd, output=None, raise_on_error=True):
     if output is True:
@@ -336,7 +333,7 @@ def git_pull_request(target_remote=None, target_branch=None,
 
     LOG.debug("Remote URL for remote `%s' is `%s'", target_remote, target_url)
 
-    hosttype, hostname, user_to_fork, reponame_to_fork = (
+    hosttype, hostname, user_to_fork, reponame_to_fork = attr.astuple(
         get_repository_id_from_url(target_url)
     )
     LOG.debug("%s user and repository to fork: %s/%s on %s",
@@ -482,6 +479,7 @@ def fork_and_push_pull_request(g, hosttype, repo_to_fork, rebase,
         else:
             forked = True
             LOG.info("Forked repository: %s", repo_forked.html_url)
+            forked_repo_id = get_repository_id_from_url(repo_forked.clone_url)
 
     if branch_prefix is None and not forked:
         branch_prefix = g_user.login
@@ -503,7 +501,7 @@ def fork_and_push_pull_request(g, hosttype, repo_to_fork, rebase,
                 ["git", "remote", "add",
                  remote_to_push, repo_forked.clone_url])
             LOG.info("Added forked repository as remote `%s'", remote_to_push)
-        head = "{}:{}".format(user, branch)
+        head = "{}:{}".format(forked_repo_id.user, branch)
     else:
         remote_to_push = target_remote
         head = "{}:{}".format(repo_to_fork.owner.login, remote_branch)

--- a/git_pull_request/tests/test_gpr.py
+++ b/git_pull_request/tests/test_gpr.py
@@ -15,6 +15,8 @@
 import os
 import unittest
 
+import attr
+
 import fixtures
 
 import git_pull_request as gpr
@@ -48,44 +50,44 @@ class BaseTestGitRepo(fixtures.TestWithFixtures):
 
 
 class TestStuff(BaseTestGitRepo):
-    def test_get_hosttype_user_repo_from_url(self):
+    def test_get_repository_id_from_url(self):
         self.assertEqual(
             ("github", "github.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "https://github.com/jd/git-pull-request.git"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "https://github.com/jd/git-pull-request.git")))
         self.assertEqual(
             ("github", "github.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "git@github.com:jd/git-pull-request.git"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "git@github.com:jd/git-pull-request.git")))
         self.assertEqual(
             ("github", "github.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "git://github.com/jd/git-pull-request.git"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "git://github.com/jd/git-pull-request.git")))
         self.assertEqual(
             ("github", "example.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "https://example.com/jd/git-pull-request.git"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "https://example.com/jd/git-pull-request.git")))
         self.assertEqual(
             ("github", "github.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "git@github.com:jd/git-pull-request"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "git@github.com:jd/git-pull-request")))
         self.assertEqual(
             ("github", "example.com", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "https://example.com/jd/git-pull-request"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "https://example.com/jd/git-pull-request")))
         self.assertEqual(
             ("github", "example.com:2222", "jd", "git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "ssh://git@example.com:2222/jd/git-pull-request"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "ssh://git@example.com:2222/jd/git-pull-request")))
         gpr.git_set_config_hosttype("pagure")
         self.assertEqual(
             ("pagure", "pagure.io", None, "pagure"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "https://pagure.io/pagure"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "https://pagure.io/pagure")))
         self.assertEqual(
             ("pagure", "src.fedoraproject.org", None, "rpms/git-pull-request"),
-            gpr.get_hosttype_hostname_user_repo_from_url(
-                "https://src.fedoraproject.org/rpms/git-pull-request"))
+            attr.astuple(gpr.get_repository_id_from_url(
+                "https://src.fedoraproject.org/rpms/git-pull-request")))
 
 
 class TestGitCommand(fixtures.TestWithFixtures):
@@ -289,21 +291,22 @@ class TestExceptionFormatting(unittest.TestCase):
 
 class TestGithubHostnameUserRepoFromUrl(BaseTestGitRepo):
     def test_git_clone_url(self):
-        expected = ("github", "example.com", "jd", "git-pull-request")
+        expected = gpr.RepositoryId(
+            "github", "example.com", "jd", "git-pull-request")
 
         self.assertEqual(
             expected,
-            gpr.get_hosttype_hostname_user_repo_from_url(
+            gpr.get_repository_id_from_url(
                 "https://example.com/jd/git-pull-request"))
 
         self.assertEqual(
             expected,
-            gpr.get_hosttype_hostname_user_repo_from_url(
+            gpr.get_repository_id_from_url(
                 "https://example.com/jd/git-pull-request.git"))
 
         self.assertEqual(
             expected,
-            gpr.get_hosttype_hostname_user_repo_from_url(
+            gpr.get_repository_id_from_url(
                 "https://example.com/jd/git-pull-request/"))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ packages = find:
 install_requires =
     pygithub
     daiquiri
+    attrs
 
 
 [options.extras_require]


### PR DESCRIPTION
Not the smallest of workarounds, because I ended up pulling in another
dependency, but it makes the code easier to follow in my opinion.

## Use an explicit attrs-based object as repository identifier.

The 4-tuple is unwieldy to access, and only works for trivial
comparisons. There are a few more places where an actual repository
identifier needs to be used, that supports the subset of case-insensitive
comparisons needed.

Note that this changes a bit the way the repositories are identified. In
particular, instead of lower-casing the whole URL before splitting it, the
URL's case is preserved, but when comparing identifiers, the comparison is
case-insensitive.

This allows preserving the upper/lower case distinction which matters in
_some_ of the GitHub APIs.

## Use the user (or org) in the fork response when creating the pull request.

GitHub usernames are case-insensitive in _most_ contexts, but not all.

For example, one might login as `username`, while the "canonical" name is
`UserName`. But the pull requests need to be created with the correct
canonical case for the username.

This re-parses the repository as forked, and preserves the case of the user
(or org) name provided there.

See Issue #100 for details.