### PR TITLE
Handle repositories with multiple pull request templates.

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -428,17 +428,22 @@ def get_pull_request_template():
     filename = "PULL_REQUEST_TEMPLATE*"
     pr_template_paths = [
         filename,
+        ".github/PULL_REQUEST_TEMPLATE/*.md",
+        ".github/PULL_REQUEST_TEMPLATE/*.txt",
         os.path.join(".github", filename),
         os.path.join("docs", filename),
         filename.lower(),
+        ".github/pull_request_template/*.md",
+        ".github/pull_request_template/*.txt",
         os.path.join(".github", filename.lower()),
         os.path.join("docs", filename.lower()),
     ]
     for path in pr_template_paths:
         templates = glob.glob(path)
-        if templates:
-            with open(templates[0]) as t:
-                return t.read()
+        for template_path in templates:
+            if os.path.isfile(template_path):
+                with open(template_path) as t:
+                    return t.read()
 
 
 def edit_title_and_message(title, message):


### PR DESCRIPTION
According to [the
documentation](https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository),
PULL_REQUEST_TEMPLATE can be a directory with multiple `.md` or `.txt`
files. Unfortunately this does not allow selecting which one. And it's
actually incorrect because as far as I can tell, the full path is matched
case-insensitive.

But it looks like it's hard to have a case-insensitive glob in Python, so
for now accept it as is.