### PR TITLE
revert: "Track the pushed branch"

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -622,7 +622,6 @@ def fork_and_push_pull_request(
             [
                 "git",
                 "push",
-                "--set-upstream",
                 "--force",
                 remote_to_push,
                 "{}:{}".format(branch, remote_branch),


### PR DESCRIPTION
This reverts commit 871ea0cb02fb48ffc14dc592bc94f82f2bd9524c.

This breaks the basic workflow: when the second call to git pull request is
done, the rebase is done against the now tracked branch which is not base
branch anymore.